### PR TITLE
Update sensor.imap_email_content.markdown

### DIFF
--- a/source/_components/sensor.imap_email_content.markdown
+++ b/source/_components/sensor.imap_email_content.markdown
@@ -9,7 +9,7 @@ sharing: true
 footer: true
 logo: smtp.png
 ha_category: Mailbox
-ha_iot_class: "Local Polling"
+ha_iot_class: "Cloud Push"
 ha_release: 0.25
 ---
 
@@ -28,6 +28,7 @@ sensor:
     port: 993
     username: USERNAME
     password: PASSWORD
+    folder: <Folder>
     senders:
       - example@gmail.com
 ```
@@ -53,6 +54,11 @@ username:
 password:
   description: Password for the IMAP server.
   required: true
+  type: string
+password:
+  description: Folder to get mails from.
+  required: false
+  default: INBOX
   type: string
 senders:
   description: A list of sender email addresses that are allowed to report state via email. Only emails received from these addresses will be processed.


### PR DESCRIPTION
Added documentation for added 'folder' config entry

**Description:**

The PR adds documentation for changes to the imap-email-content sensor. This sensor can now also read mail form another folder.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [X] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
